### PR TITLE
Fix/firefox svg

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hermesgermany/last-mile-components",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "main": "./dist/lmc.umd.js",
   "module": "./dist/lmc.es.js",

--- a/src/lib/sidebar-components/Sidebar/Sidebar.tsx
+++ b/src/lib/sidebar-components/Sidebar/Sidebar.tsx
@@ -15,9 +15,10 @@ function LogoImage(
   >
 ) {
   return (
-    <div className="tw-p-1">
-      <img {...props} className="tw-h-full tw-w-full tw-object-scale-down" />
-    </div>
+    <img
+      {...props}
+      className="tw-box-border tw-h-full tw-w-full tw-object-scale-down tw-p-1"
+    />
   )
 }
 


### PR DESCRIPTION
In Firefox, the SVG logo was not visible in the sidebar because the outer div of the <img> tag had no width. Chrome handles this differently, so we hadn't noticed it before.